### PR TITLE
fix(#1): add tabindex to cards to trigger animation on Safari mobile

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -132,7 +132,7 @@ const codingActivity = {
 
         <section class="mb-[24px]">
           <h4>Last 7 Days</h4>
-          <ul class="">
+          <ul tabindex="0">
             {
               wakatimeAnalyticsData.last7Days.languages.data
                 .slice(0, 4)
@@ -155,7 +155,7 @@ const codingActivity = {
 
         <section>
           <h4>All Time</h4>
-          <ul>
+          <ul tabindex="0">
             {
               wakatimeAnalyticsData.allTime.languages.data
                 .slice(0, 4)
@@ -181,7 +181,7 @@ const codingActivity = {
       <!-- START Coding Activity -->
       <section>
         <h3>Coding Activity</h3>
-        <ul>
+        <ul tabindex="0">
           <li>
             <div>
               <div>
@@ -212,7 +212,7 @@ const codingActivity = {
       <!-- START Other Tools Used -->
       <section>
         <h3>Other Tools Used</h3>
-        <ul>
+        <ul tabindex="0">
           <li>
             <div>
               <div>


### PR DESCRIPTION
## Summary

Safari mobile doesn’t support hover-based animations on touch devices, causing the card flip animation to fail. This PR adds a `tabindex` attribute to `<ul>` elements to simulate focus and trigger the animation as a temporary workaround.

## Problem

- On Safari mobile, hover-based card animations do not work, resulting in a broken user experience.

## Solution

- Added `tabindex` to the relevant `<ul>` elements to allow focus, which in turn triggers the card flip animation even on touch devices.
- Approach based on guidance from [CSS :hover not working on iOS Safari and Chrome](https://stackoverflow.com/questions/35187970/css-hover-not-working-on-ios-safari-and-chrome).

## Recommendation

- In the future, consider refactoring the animation logic to use click-based triggers for improved cross-browser compatibility.

## Related Issue

- #1

## References

- [CSS :hover not working on iOS Safari and Chrome – Stack Overflow](https://stackoverflow.com/questions/35187970/css-hover-not-working-on-ios-safari-and-chrome)

## Testing

Tested on:
- iOS Safari
- Android Chrome
- Android Edge
- Linux Chrome

## Checklist

- [x] Fixes Safari mobile animation issue
- [x] Adds tabindex to `<ul>` elements
- [x] Tested on multiple devices

## Additional Notes

- This is a temporary workaround. Long-term solution should transition to click-based animation triggers.